### PR TITLE
Optimization of MaxHeapSize with Docker-based memory limiting capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added the ability to configure the memory limits with `cesapp edit-config`
+- Optimized max heap size in limited dockerized environments (#61)
+
 ## [v2020.4-1] - 2020-04-06
 ### Added
 - Jenkinsfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added the ability to configure the memory limits with `cesapp edit-config`
-- Ability to configure the `MaxRamPercentage` and `MinRamPercentage` for the CAS process inside the container via `cesapp edit-conf` (#3)
+- Ability to configure the `MaxRamPercentage` and `MinRamPercentage` for the PlantUML process inside the container via `cesapp edit-conf` (#3)
 
 ## [v2020.4-1] - 2020-04-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgraded the java base image to version `8u252-1`
+
 ### Added
 
 - Added the ability to configure the memory limits with `cesapp edit-config`
-- Optimized max heap size in limited dockerized environments (#61)
+- Ability to configure the `MaxRamPercentage` and `MinRamPercentage` for the CAS process inside the container via `cesapp edit-conf` (#3)
 
 ## [v2020.4-1] - 2020-04-06
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN set -x \
 
 
 
-FROM registry.cloudogu.com/official/java:11.0.5-1
+FROM registry.cloudogu.com/official/java:8u252-1
 
 LABEL NAME="official/plantuml" \
    VERSION="2020.4-1" \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library(['github.com/cloudogu/ces-build-lib@a46de28', 'github.com/cloudogu/dogu-build-lib@ff65ba3'])
+@Library(['github.com/cloudogu/ces-build-lib@1.44.3', 'github.com/cloudogu/dogu-build-lib@v1.1.0'])
 import com.cloudogu.ces.cesbuildlib.*
 import com.cloudogu.ces.dogubuildlib.*
 

--- a/dogu.json
+++ b/dogu.json
@@ -15,6 +15,24 @@
   "Dependencies": [
     "nginx"
   ],
+  "Configuration": [
+    {
+      "Name": "container_config/memory_limit",
+      "Description": "Limits the container's memory usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte).",
+      "Optional": true,
+      "Validation": {
+        "Type": "BINARY_MEASUREMENT"
+      }
+    },
+    {
+      "Name": "container_config/swap_limit",
+      "Description": "Limits the container's swap memory usage. Use zero or a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte). 0 will disable swapping.",
+      "Optional": true,
+      "Validation": {
+        "Type": "BINARY_MEASUREMENT"
+      }
+    }
+  ],
   "HealthCheck": {
     "Type": "tcp",
     "Port": 8080

--- a/dogu.json
+++ b/dogu.json
@@ -31,6 +31,24 @@
       "Validation": {
         "Type": "BINARY_MEASUREMENT"
       }
+    },
+    {
+      "Name": "container_config/java_max_ram_percentage",
+      "Description":"Limits the heap stack size of the PlantUML process to the configured percentage of the available physical memory when the container has more than approx. 250 MB of memory available. Is only considered when a memory_limit is set. Use a valid float value with decimals between 0 and 100 (f. ex. 55.0 for 55%). Default value for PlantUML: 25%",
+      "Optional": true,
+      "Default": "25.0",
+      "Validation": {
+        "Type": "FLOAT_PERCENTAGE_HUNDRED"
+      }
+    },
+    {
+      "Name": "container_config/java_min_ram_percentage",
+      "Description":"Limits the heap stack size of the PlantUML process to the configured percentage of the available physical memory when the container has less than approx. 250 MB of memory available. Is only considered when a memory_limit is set. Use a valid float value with decimals between 0 and 100 (f. ex. 55.0 for 55%). Default value for PlantUML: 50%",
+      "Optional": true,
+      "Default": "50.0",
+      "Validation": {
+        "Type": "FLOAT_PERCENTAGE_HUNDRED"
+      }
     }
   ],
   "HealthCheck": {

--- a/resources/opt/apache-tomcat/bin/setenv.sh
+++ b/resources/opt/apache-tomcat/bin/setenv.sh
@@ -3,3 +3,7 @@ JAVA_OPTS="$JAVA_OPTS -Djava.awt.headless=true"
 JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true"
 JAVA_OPTS="$JAVA_OPTS -Djavax.net.ssl.trustStore=/etc/ssl/truststore.jks"
 JAVA_OPTS="$JAVA_OPTS -Djavax.net.ssl.trustStorePassword=changeit"
+if [ "$(doguctl config "container_config/memory_limit" -d "empty")" != "empty" ];  then
+  JAVA_OPTS="$JAVA_OPTS -XX:MaxRAMPercentage=85.0"
+  JAVA_OPTS="$JAVA_OPTS -XX:MinRAMPercentage=50.0"
+fi

--- a/resources/opt/apache-tomcat/bin/setenv.sh
+++ b/resources/opt/apache-tomcat/bin/setenv.sh
@@ -4,6 +4,11 @@ JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true"
 JAVA_OPTS="$JAVA_OPTS -Djavax.net.ssl.trustStore=/etc/ssl/truststore.jks"
 JAVA_OPTS="$JAVA_OPTS -Djavax.net.ssl.trustStorePassword=changeit"
 if [ "$(doguctl config "container_config/memory_limit" -d "empty")" != "empty" ];  then
-  JAVA_OPTS="$JAVA_OPTS -XX:MaxRAMPercentage=85.0"
-  JAVA_OPTS="$JAVA_OPTS -XX:MinRAMPercentage=50.0"
+  # Retrieve configurable java limits from etcd, valid default values exist
+  MEMORY_LIMIT_MAX_PERCENTAGE=$(doguctl config "container_config/java_max_ram_percentage")
+  MEMORY_LIMIT_MIN_PERCENTAGE=$(doguctl config "container_config/java_min_ram_percentage")
+
+  echo "Setting memory limits to MaxRAMPercentage: ${MEMORY_LIMIT_MAX_PERCENTAGE} and MinRAMPercentage: ${MEMORY_LIMIT_MIN_PERCENTAGE}..."
+  JAVA_OPTS="$JAVA_OPTS -XX:MaxRAMPercentage=${MEMORY_LIMIT_MAX_PERCENTAGE}"
+  JAVA_OPTS="$JAVA_OPTS -XX:MinRAMPercentage=${MEMORY_LIMIT_MIN_PERCENTAGE}"
 fi


### PR DESCRIPTION
Fixes #3 

With Docker-based memory limiting capabilities, it is possible to restrict the memory for the PlantUML-Dogu. Since version 10, Java can automatically detect container limits. However, Java generally only claims 25% of the physical memory (of the container) as the maximum heap size. This issue aims to optimize the maximum heap size while considering interferences with other possible programs in the container.

Set the MaxRamPercentage and MinRamPercentage to recommended values:
MaxRamPercentage=85.0
MinRamPercentage=50.0